### PR TITLE
use JSpecify @NonNull annotation in favour of deprecated @Nonnull ann…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 }
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.1'
+	id 'org.springframework.boot' version '3.4.4'
 	id 'io.spring.dependency-management' version '1.1.0'
 	id 'com.vaadin' version "$vaadinVersion"
 }

--- a/src/main/java/com/example/application/endpoints/helloreact/HelloEndpoint.java
+++ b/src/main/java/com/example/application/endpoints/helloreact/HelloEndpoint.java
@@ -2,7 +2,7 @@ package com.example.application.endpoints.helloreact;
 
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import com.vaadin.hilla.BrowserCallable;
-import com.vaadin.hilla.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 @BrowserCallable
 @AnonymousAllowed
@@ -26,7 +26,7 @@ public class HelloEndpoint {
      * @param name that assumed to be nonnull
      * @return a nonnull greeting
      */
-    @Nonnull
+    @NonNull
     public String sayHello(String name) {
         if (name.isEmpty()) {
             return "Hello stranger";


### PR DESCRIPTION
…otation from Hilla

## Description

Use JSpecify @NonNull annotation, because Vaadin 24.7 release marks Hilla's @NonNull annotation as deprecated.

Fixes #101

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
